### PR TITLE
Force unsaved items to render their form fields

### DIFF
--- a/condensedinlinepanel/edit_handlers.py
+++ b/condensedinlinepanel/edit_handlers.py
@@ -118,6 +118,11 @@ class BaseCondensedInlinePanelFormSet(BaseChildFormSet):
                     'extra': get_form_extra_data(form),
                     'errors': json.loads(form.errors.as_json()),
                     'position': i + 1,
+
+                    # #20 - Force the form to render its fields if it's not saved
+                    # (As it doesn't have an object in the database, it needs to be
+                    # recreated on every form submission)
+                    'forceFormRender': form.instance.id is None,
                 }
                 for i, form in enumerate(self)
             ],

--- a/condensedinlinepanel/static/condensedinlinepanel/src/components/Card.tsx
+++ b/condensedinlinepanel/static/condensedinlinepanel/src/components/Card.tsx
@@ -189,6 +189,10 @@ export class Card extends React.Component<CardProps, CardState> {
     shouldRenderForm(props=this.props) {
         /* Returns true if we need the form HTML to be rendered in the DOM */
 
+        if (props.form.forceFormRender) {
+            return true;
+        }
+
         // Note, we still need the form HTML when the form has been edited/deleted
         // so the changes get submitted back to Wagtail
         return (props.form.isEditing || props.form.hasChanged || props.form.isDeleted) && props.canEdit;

--- a/condensedinlinepanel/static/condensedinlinepanel/src/types.ts
+++ b/condensedinlinepanel/static/condensedinlinepanel/src/types.ts
@@ -27,6 +27,9 @@ export interface Form {
     // The current position of the form in the panel (1 based)
     position: number,
 
+    // Set to true will force the form fields to be rendered in HTML
+    forceFormRender?: boolean,
+
     // The field data. Mapping of field names to values
     fields: {[name: string]: string;},
 


### PR DESCRIPTION
Unsaved items need to resubmit their values every time or
django-modelcluster will delete them.

Fixes #20