### PR TITLE
[WIP] Tree structured inline panels

### DIFF
--- a/condensedinlinepanel/models.py
+++ b/condensedinlinepanel/models.py
@@ -1,0 +1,8 @@
+from django.db import models
+
+
+class Structured(models.Model):
+    depth = models.PositiveIntegerField(default=1)
+
+    class Meta:
+        abstract = True

--- a/condensedinlinepanel/static/condensedinlinepanel/src/components/CardSet.tsx
+++ b/condensedinlinepanel/static/condensedinlinepanel/src/components/CardSet.tsx
@@ -36,11 +36,11 @@ export class CardSet extends React.Component<CardSetProps, {}> {
 
         for (let i = 0; i < forms.length; i++) {
             let depth = forms[i].props.form.depth;
-            let wasLastChild = lastDepth > depth;  // Was the last card the last child of its parent?
 
-            if (wasLastChild) {
-                // Add an extra gap at the end of the list of children
-                newForms.push(<DroppableGap key={'gap-' + positionId} position={positionId++} depth={lastDepth} dndKey={this.props.dndKey||this.props.formsetPrefix} onDND={onDND} onAdd={onAdd} />);
+            // Add an extra gap at the end of the list of children
+            while (lastDepth > depth) {
+                newForms.push(<DroppableGap key={`gap-lastchild-${positionId}-${lastDepth}`} position={positionId} depth={lastDepth} dndKey={this.props.dndKey||this.props.formsetPrefix} onDND={onDND} onAdd={onAdd} />);
+                lastDepth--;
             }
 
             // Add a gap
@@ -52,6 +52,12 @@ export class CardSet extends React.Component<CardSetProps, {}> {
             lastDepth = depth;
         }
 
+        // Add an extra gap at the end of the list of children
+        while (lastDepth > 1) {
+            newForms.push(<DroppableGap key={`gap-lastchild-${positionId}-${lastDepth}`} position={positionId} depth={lastDepth} dndKey={this.props.dndKey||this.props.formsetPrefix} onDND={onDND} onAdd={onAdd} />);
+            lastDepth--;
+        }
+
         // Add the bottom gap
         newForms.push(<DroppableGap key={'gap-' + positionId} position={positionId++} depth={1} dndKey={this.props.dndKey||this.props.formsetPrefix} onDND={onDND} onAdd={onAdd} />);
 
@@ -60,6 +66,7 @@ export class CardSet extends React.Component<CardSetProps, {}> {
 
     render() {
         let renderedCards = [];
+        let deletedCards = [];
 
         // The DND event handler
 
@@ -166,21 +173,27 @@ export class CardSet extends React.Component<CardSetProps, {}> {
             };
 
             // Render the card component
-            renderedCards.push(<DraggableCard key={form.id}
-                                     form={form}
-                                     renderCardHeader={this.props.renderCardHeader}
-                                     canEdit={this.props.canEdit}
-                                     canDelete={this.props.canDelete}
-                                     canOrder={this.props.canOrder}
-                                     canStructure={this.props.canStructure}
-                                     template={this.props.formTemplate}
-                                     formPrefix={`${this.props.formsetPrefix}-${form.id.toString()}`}
-                                     customiseActions={this.props.customiseCardActions}
-                                     dndKey={this.props.dndKey||this.props.formsetPrefix}
-                                     onDND={onDND}
-                                     onEditStart={onEditStart}
-                                     onEditClose={onEditClose}
-                                     onDelete={onDelete} />);
+            let card = <DraggableCard key={form.id}
+                form={form}
+                renderCardHeader={this.props.renderCardHeader}
+                canEdit={this.props.canEdit}
+                canDelete={this.props.canDelete}
+                canOrder={this.props.canOrder}
+                canStructure={this.props.canStructure}
+                template={this.props.formTemplate}
+                formPrefix={`${this.props.formsetPrefix}-${form.id.toString()}`}
+                customiseActions={this.props.customiseCardActions}
+                dndKey={this.props.dndKey||this.props.formsetPrefix}
+                onDND={onDND}
+                onEditStart={onEditStart}
+                onEditClose={onEditClose}
+                onDelete={onDelete} />;
+
+            if (form.isDeleted) {
+                deletedCards.push(card);
+            } else {
+                renderedCards.push(card);
+            }
         }
 
         // Add gap objects into the cards
@@ -201,6 +214,7 @@ export class CardSet extends React.Component<CardSetProps, {}> {
         return <div>
             {addButton}
             {renderedCards}
+            {deletedCards}
         </div>;
     }
 }

--- a/condensedinlinepanel/static/condensedinlinepanel/src/components/Gap.tsx
+++ b/condensedinlinepanel/static/condensedinlinepanel/src/components/Gap.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import {DropTarget} from 'react-dnd';
 
-export type onAddFn = (position: number) => void;
-export type onDNDFn = (formId: number, position: number) => void;
+export type onAddFn = (position: number, depth: number) => void;
+export type onDNDFn = (formId: number, position: number, depth: number) => void;
 
 export interface GapProps {
     position: number,
+    depth: number,
     onAdd: onAddFn,
     dndKey: string,
     isOver?: boolean
@@ -21,7 +22,7 @@ export class Gap extends React.Component<GapProps, {}> {
 
     drop(formId: number) {
         if (this.props.onDND) {
-            this.props.onDND(formId, this.props.position);
+            this.props.onDND(formId, this.props.position, this.props.depth);
         }
     }
 
@@ -32,18 +33,18 @@ export class Gap extends React.Component<GapProps, {}> {
         if (this.props.isOver) {
             classes.push('condensed-inline-panel__gap--over');
 
-            gap = <div className={classes.join(' ')}>
+            gap = <div className={classes.join(' ')} data-depth={this.props.depth}>
                       <div className="condensed-inline-panel__gap-pseudoform" />
                   </div>;
         } else {
             let onAdd = (e: any) => {
-                this.props.onAdd(this.props.position);
+                this.props.onAdd(this.props.position, this.props.depth);
 
                 e.preventDefault();
                 return false;
             };
 
-            gap = <div className={classes.join(' ')}>
+            gap = <div className={classes.join(' ')} data-depth={this.props.depth}>
                       <a className="condensed-inline-panel__add-button icon icon-plus-inverse" href="#" onClick={onAdd}></a>
                   </div>;
         }

--- a/condensedinlinepanel/static/condensedinlinepanel/src/condensedinlinepanel.scss
+++ b/condensedinlinepanel/static/condensedinlinepanel/src/condensedinlinepanel.scss
@@ -189,8 +189,6 @@ $card-header-left-padding: 1.5em;
     // Add button
 
     &__gap {
-        text-align: right;
-
         &[data-depth="2"] {
             margin-left: 20px;
         }
@@ -205,10 +203,6 @@ $card-header-left-padding: 1.5em;
 
         &:hover {
             color: darken(#43B1B0, 10%);
-        }
-
-        &:before {
-            margin-right: 0;
         }
     }
 

--- a/condensedinlinepanel/static/condensedinlinepanel/src/condensedinlinepanel.scss
+++ b/condensedinlinepanel/static/condensedinlinepanel/src/condensedinlinepanel.scss
@@ -28,6 +28,14 @@ $card-header-left-padding: 1.5em;
         background-color: #FFF;
         border: 1px solid #EEE;
         transition: background-color 0.2s ease 0s;
+
+        &[data-depth="2"] {
+            margin-left: 20px;
+        }
+
+        &[data-depth="3"] {
+            margin-left: 40px;
+        }
     }
 
     &__card--editing {
@@ -182,6 +190,14 @@ $card-header-left-padding: 1.5em;
 
     &__gap {
         text-align: right;
+
+        &[data-depth="2"] {
+            margin-left: 20px;
+        }
+
+        &[data-depth="3"] {
+            margin-left: 40px;
+        }
     }
 
     &__add-button {

--- a/condensedinlinepanel/static/condensedinlinepanel/src/condensedinlinepanel.tsx
+++ b/condensedinlinepanel/static/condensedinlinepanel/src/condensedinlinepanel.tsx
@@ -16,6 +16,7 @@ interface Options {
     canEdit?: boolean,
     canDelete?: boolean,
     canOrder?: boolean,
+    canStructure?: boolean,
     renderCardHeader?: renderCardHeaderFn,
     panelLabel?: string,
 }
@@ -30,6 +31,7 @@ export function init(id: string, options: Options = {}) {
     const canEdit = options['canEdit'] || true;
     const canDelete = options['canDelete'] || canEdit;
     const canOrder = options['canOrder'] || false;
+    const canStructure = options['canStructure'] || false;
     const renderCardHeader = options['renderCardHeader'] || renderCardHeaderDefault;
     const panelLabel = options['panelLabel'] || "Add";
 
@@ -69,6 +71,7 @@ export function init(id: string, options: Options = {}) {
                                  canEdit={canEdit}
                                  canDelete={canDelete}
                                  canOrder={canOrder}
+                                 canStructure={canStructure}
                                  store={store}
                                  emptyForm={state.emptyForm}
                                  formTemplate={element.dataset['formTemplate']||''}
@@ -89,6 +92,23 @@ export function init(id: string, options: Options = {}) {
 
             if (sortOrderField instanceof HTMLInputElement) {
                 sortOrderField.value = JSON.stringify(sortOrders);
+            }
+        });
+    }
+
+    // Keep depth field up to date
+    if (canStructure) {
+        let depthField = element.getElementsByClassName('condensed-inline-panel__depth')[0];
+        store.subscribe(() => {
+            let state = store.getState() || emptyState();
+            let depths = [];
+
+            for (let i = 0; i< state.forms.length; i++) {
+                depths.push(state.forms[i].depth);
+            }
+
+            if (depthField instanceof HTMLInputElement) {
+                depthField.value = JSON.stringify(depths);
             }
         });
     }

--- a/condensedinlinepanel/static/condensedinlinepanel/src/state.ts
+++ b/condensedinlinepanel/static/condensedinlinepanel/src/state.ts
@@ -34,6 +34,7 @@ export interface MoveFormAction {
     type: "MOVE_FORM",
     formId: number,
     position: number,
+    depth: number,
 }
 
 // Need to define an action without any required fields to satisfy type checking
@@ -56,6 +57,7 @@ export function emptyState(): State {
             isDeleted: false,
             hasChanged: false,
             position: 1,
+            depth: 1,
             fields: {},
             extra: {},
             errors: {},
@@ -94,6 +96,7 @@ export function reducer(state: State|null = null, action: Action): State|null {
         let newPosition = action.position;
         if (newPosition > previousPosition) newPosition--;
         movedForm.position = newPosition;
+        movedForm.depth = action.depth;
 
         // Update sort orders of all other forms
         for (let i = 0; i < newForms.length; i++) {

--- a/condensedinlinepanel/static/condensedinlinepanel/src/types.ts
+++ b/condensedinlinepanel/static/condensedinlinepanel/src/types.ts
@@ -26,6 +26,9 @@ export interface Form {
     // The current position of the form in the panel (1 based)
     position: number,
 
+    // The current depth of the form in the panel (1 based)
+    depth: number,
+
     // Set to true will force the form fields to be rendered in HTML
     forceFormRender?: boolean,
 

--- a/condensedinlinepanel/templates/condensedinlinepanel/condensedinlinepanel.html
+++ b/condensedinlinepanel/templates/condensedinlinepanel/condensedinlinepanel.html
@@ -6,6 +6,10 @@
         <input class="condensed-inline-panel__sort-order" type="hidden" name="{{ self.formset.prefix }}-ORDER">
     {% endif %}
 
+    {% if self.formset.can_structure %}
+        <input class="condensed-inline-panel__depth" type="hidden" name="{{ self.formset.prefix }}-DEPTH">
+    {% endif %}
+
     {{ self.formset.management_form }}
 
     <div class="condensed-inline-panel__ui-container"></div>

--- a/condensedinlinepanel/templates/condensedinlinepanel/condensedinlinepanel.js
+++ b/condensedinlinepanel/templates/condensedinlinepanel/condensedinlinepanel.js
@@ -2,6 +2,7 @@
     CondensedInlinePanel.init('id_{{ self.formset.prefix }}', {
         summaryTextField: '{{ self.formset.summary_text_field|escapejs }}',
         canOrder: {{ self.formset.can_order|lower }},
+        canStructure: {{ self.formset.can_structure|lower }},
         panelLabel: "{{ self.label }}",
         renderCardHeader: function(form) {
             {% if self.card_header_from_field %}


### PR DESCRIPTION
This PR adds tree structuring into condensed inline panels!  I think this would be mainly helpful for use on menu/taxonomy snippets/settings but I'd also like to try using this for things outside forms, such as configuring collections.

![cip-trees](https://user-images.githubusercontent.com/1093808/35872907-17bbf15e-0b60-11e8-96a6-c8c59ae96062.png)

To enable it, just add the ``condensedinlinepanel.models.Structured`` model as a base to your inline child model (just like you currently do for ``Orderable``). This will require a migration. This adds an integer field to your model called ``depth``, which is used in conjunction with the ``sort_order`` field provided by ``Orderable`` to build the tree structure.

TODO:

 - [ ] Show blue box underneath when dragging a card over another card
 - [ ] Drag and drop doesn't carry descendants
 - [ ] Fix bug when form validation errors happen
 - [ ] Dropping at the end of a branch is a bit fiddly
 - [x] Add max depth limitation (or make styling work for infinite number of depths)
 - [ ] Adding forms when other forms have been deleted sometimes adds the new form in the wrong place
 - [ ] Helpers for traversing the tree in Python