### PR TITLE
Implemented support for snippet and document choosers

### DIFF
--- a/condensedinlinepanel/edit_handlers.py
+++ b/condensedinlinepanel/edit_handlers.py
@@ -127,6 +127,10 @@ class BaseCondensedInlinePanelFormSet(BaseChildFormSet):
                             data[field_name] = {
                                 'title': obj.title
                             }
+                        else:
+                            data[field_name] = {
+                                'title': str(obj)
+                            }
 
             return data
 

--- a/condensedinlinepanel/static/condensedinlinepanel/src/components/FormContainer.tsx
+++ b/condensedinlinepanel/static/condensedinlinepanel/src/components/FormContainer.tsx
@@ -125,5 +125,26 @@ export class FormContainer extends React.Component<FormContainerProps, {}> {
                 }
             }
         }
+
+        // HACK: Make snippet choosers work
+        let snippetChoosers = formElement.getElementsByClassName('snippet-chooser');
+        for (let i = 0; i < snippetChoosers.length; i++) {
+            let snippetChooser = snippetChoosers.item(i);
+            let match = snippetChooser.id.match(/id_[^-]*-\d+-([^-]*)-chooser/);
+
+            if (match) {
+                let fieldName = match[1];
+
+                if (this.props.form.fields[fieldName]) {
+                    // Field has a value!
+
+                    // Remove blank class
+                    snippetChooser.classList.remove('blank');
+
+                    // Set title
+                    snippetChooser.getElementsByClassName('title')[0].textContent = this.props.form.extra[fieldName]['title'];
+                }
+            }
+        }
     }
 }

--- a/condensedinlinepanel/static/condensedinlinepanel/src/components/FormContainer.tsx
+++ b/condensedinlinepanel/static/condensedinlinepanel/src/components/FormContainer.tsx
@@ -146,5 +146,26 @@ export class FormContainer extends React.Component<FormContainerProps, {}> {
                 }
             }
         }
+
+        // HACK: Make document choosers work
+        let documentChoosers = formElement.getElementsByClassName('document-chooser');
+        for (let i = 0; i < documentChoosers.length; i++) {
+            let documentChooser = documentChoosers.item(i);
+            let match = documentChooser.id.match(/id_[^-]*-\d+-([^-]*)-chooser/);
+
+            if (match) {
+                let fieldName = match[1];
+
+                if (this.props.form.fields[fieldName]) {
+                    // Field has a value!
+
+                    // Remove blank class
+                    documentChooser.classList.remove('blank');
+
+                    // Set title
+                    documentChooser.getElementsByClassName('title')[0].textContent = this.props.form.extra[fieldName]['title'];
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This fills in the initial values for snippet/document choosers. Got to hack these in like the others as Wagtail implements this logic in the Django template.

Fixes #45