### PR TITLE
[Draftail fix] Pass field values through widget.format_value()

### DIFF
--- a/condensedinlinepanel/edit_handlers.py
+++ b/condensedinlinepanel/edit_handlers.py
@@ -140,7 +140,7 @@ class BaseCondensedInlinePanelFormSet(BaseChildFormSet):
                     'id': i,
                     'instanceAsStr': six.text_type(form.instance),
                     'fields': {
-                        field_name: form[field_name].value()
+                        field_name: form[field_name].field.widget.format_value(form[field_name].value())
                         for field_name in form.fields.keys()
                     },
                     'extra': get_form_extra_data(form),
@@ -156,7 +156,7 @@ class BaseCondensedInlinePanelFormSet(BaseChildFormSet):
             ],
             'emptyForm': {
                 'fields': {
-                    field_name: self.empty_form[field_name].value()
+                    field_name: self.empty_form[field_name].field.widget.format_value(self.empty_form[field_name].value())
                     for field_name in self.empty_form.fields.keys()
                 }
             }


### PR DESCRIPTION
Fixes #51 and #48

This allows the code within Wagtail's Draftail widget that converts the internal HTML format into JSON to run.

https://github.com/wagtail/wagtail/blob/72bc5fff6f6d12daf1dc8dc630a3159dafd30e5b/wagtail/admin/rich_text/editors/draftail/__init__.py#L51-L59