### PR TITLE
solves issue #57

### DIFF
--- a/condensedinlinepanel/edit_handlers.py
+++ b/condensedinlinepanel/edit_handlers.py
@@ -144,7 +144,7 @@ class BaseCondensedInlinePanelFormSet(BaseChildFormSet):
                     'id': i,
                     'instanceAsStr': six.text_type(form.instance),
                     'fields': {
-                        field_name: form[field_name].field.widget.format_value(form[field_name].value()) or form[field_name].value()
+                        field_name: form[field_name].value()
                         for field_name in form.fields.keys()
                     },
                     'extra': get_form_extra_data(form),
@@ -160,7 +160,7 @@ class BaseCondensedInlinePanelFormSet(BaseChildFormSet):
             ],
             'emptyForm': {
                 'fields': {
-                    field_name: self.empty_form[field_name].field.widget.format_value(self.empty_form[field_name].value()) or self.empty_form[field_name].value()
+                    field_name: self.empty_form[field_name].value()
                     for field_name in self.empty_form.fields.keys()
                 }
             }


### PR DESCRIPTION
Update edit_handlers.py to use form['field_name'].value() because I believe this to be correct in Django 2.2.8 

Please make sure to check properly because I do not know why the former implementation had been choosen as it was.