### PR TITLE
Fix new card header rendering

### DIFF
--- a/condensedinlinepanel/templates/condensedinlinepanel/condensedinlinepanel.js
+++ b/condensedinlinepanel/templates/condensedinlinepanel/condensedinlinepanel.js
@@ -8,7 +8,7 @@
                 {# Get the card header value from a field and escape it #}
                 var value = form.fields['{{ self.card_header_from_field|escapejs }}'];
                 if (form.isNew){
-                  value = "{{ self.new_card_header }}";
+                  value = "{{ self.new_card_header_text }}";
                 }
                 var needsEscaping = true;
             {% elif self.card_header_from_js %}
@@ -22,7 +22,7 @@
             {% else %}
                 {# Developer forgot to set this #}
                 if (form.instanceAsStr===undefined){
-                  var value = "{{ self.new_card_header }}";
+                  var value = "{{ self.new_card_header_text }}";
                 } else {
                   var value = form.instanceAsStr;
                 }


### PR DESCRIPTION
I was wondering why setting `new_card_header_text` while initializing a `CondensedInlinePanel` wasn't working (see also issue #50). Digging a bit into the source code, I found out that in the JS file the parameter is referred to as `new_card_header`. Changing it to `new_card_header_text` makes it work as intended.