### PR TITLE
Django 3+

### DIFF
--- a/condensedinlinepanel/wagtail_hooks.py
+++ b/condensedinlinepanel/wagtail_hooks.py
@@ -1,4 +1,7 @@
-from django.contrib.staticfiles.templatetags.staticfiles import static
+try:
+    from django.contrib.staticfiles.templatetags.staticfiles import static
+except (ModuleNotFoundError, ImportError):
+    from django.templatetags.static import static
 
 from wagtail.core import hooks
 

--- a/condensedinlinepanel/wagtail_hooks.py
+++ b/condensedinlinepanel/wagtail_hooks.py
@@ -1,9 +1,10 @@
-try:
-    from django.contrib.staticfiles.templatetags.staticfiles import static
-except (ModuleNotFoundError, ImportError):
-    from django.templatetags.static import static
-
+import django
 from wagtail.core import hooks
+
+if django.VERSION >= (3, 0):
+    from django.templatetags.static import static
+else:
+    from django.contrib.staticfiles.templatetags.staticfiles import static
 
 
 # JS/CSS for custom edit handlers


### PR DESCRIPTION
Fix ModuleNotFoundError: No module named 'django.contrib.staticfiles.templatetags'